### PR TITLE
Add default skeleton for home-manager templates

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -14,6 +14,8 @@
   modules = import ./modules; # NixOS modules
   overlays = import ./overlays; # nixpkgs overlays
 
+  home-manager.modules = pkgs.lib.attrValues (import ./home-manager/modules);
+
   example-package = pkgs.callPackage ./pkgs/example-package { };
   # some-qt5-package = pkgs.libsForQt5.callPackage ./pkgs/some-qt5-package { };
   # ...

--- a/home-manager/modules/default.nix
+++ b/home-manager/modules/default.nix
@@ -1,0 +1,6 @@
+{
+  # Add your HomeManager modules here
+  #
+  # my-module = ./my-module;
+}
+


### PR DESCRIPTION
Simultaneous PR with https://github.com/nix-community/NUR/pull/98.

Which has a dep on https://github.com/rycee/home-manager/pull/470.