### PR TITLE
Fix builds of free packages

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -17,7 +17,7 @@ let
 
   isReserved = n: n == "lib" || n == "overlays" || n == "modules";
   isDerivation = p: isAttrs p && p ? type && p.type == "derivation";
-  isBuildable = p: !(p.meta.broken or false) && p.meta.license.free or false;
+  isBuildable = p: !(p.meta.broken or false) && p.meta.license.free or true;
   isCacheable = p: !(p.preferLocalBuild or false);
   shouldRecurseForDerivations = p: isAttrs p && p.recurseForDerivations or false;
 


### PR DESCRIPTION
The license.free field is set to `false` for non-free packages, for free packages it is set to `true` or is missing entirely. Thus we need to default the case of a missing field to `true`, not `false`.