### PR TITLE
Update nix version in travis.yml to 2.3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: nix
+nix: 2.3.4
 
 sudo: false
 


### PR DESCRIPTION
Follow up to bumping this version in the NUR repository.

The default nix version is quite old and has a problematic or missing `fromTOML` implementation.

Also see https://github.com/nix-community/NUR/pull/217