### PR TITLE
README: change instructions to use templating mechanism instead of forking

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Setup
 
-1. Fork this repo
+1. Click on [Use this template](https://github.com/nix-community/nur-packages-template/generate) to start a repo based on this template. (Do _not_ fork it.)
 2. Add your packages to the [pkgs](./pkgs) directory and to
    [default.nix](./default.nix)
    * Remember to mark the broken packages as `broken = true;` in the `meta`


### PR DESCRIPTION
Pull requests from forks default to the original repo on GitHub, which can lead to misdirected PRs.
Updating the instructions to use GitHub's template mechanism should spare new adopters from making a fool of themselves.