### PR TITLE
Fix GitHub workflow badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 **My personal [NUR](https://github.com/nix-community/NUR) repository**
 
 <!-- Remove this if you don't use github actions -->
-![Build and populate cache](https://github.com/nix-community/<YOUR-GITHUB-USER>/workflows/Build%20and%20populate%20cache/badge.svg)
+![Build and populate cache](https://github.com/<YOUR-GITHUB-USER>/nur-packages/workflows/Build%20and%20populate%20cache/badge.svg)
 
 <!--
 Uncomment this if you use travis:


### PR DESCRIPTION
The link to the badge should be `github.com/<YOUR-GITHUB-USER>/nur-packages/...` instead of `github.com/nix-community/<YOUR-GITHUB-USER>/...`