### PR TITLE
default: fix typo in the special attributes name

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -9,7 +9,7 @@
 { pkgs ? import <nixpkgs> { } }:
 
 {
-  # The `lib`, `modules`, and `overlay` names are special
+  # The `lib`, `modules`, and `overlays` names are special
   lib = import ./lib { inherit pkgs; }; # functions
   modules = import ./modules; # NixOS modules
   overlays = import ./overlays; # nixpkgs overlays


### PR DESCRIPTION
The special attribute is "overlays" (plural)