### PR TITLE
ci.nix: make isBuildable work when `p.meta.license` is a list

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -15,7 +15,10 @@ with builtins;
 let
   isReserved = n: n == "lib" || n == "overlays" || n == "modules";
   isDerivation = p: isAttrs p && p ? type && p.type == "derivation";
-  isBuildable = p: !(p.meta.broken or false) && p.meta.license.free or true;
+  isBuildable = p: let
+    licenseFromMeta = p.meta.license or [];
+    licenseList = if builtins.isList licenseFromMeta then licenseFromMeta else [licenseFromMeta];
+  in !(p.meta.broken or false) && builtins.all (license: license.free or true) licenseList;
   isCacheable = p: !(p.preferLocalBuild or false);
   shouldRecurseForDerivations = p: isAttrs p && p.recurseForDerivations or false;
 


### PR DESCRIPTION
Currently when `p.meta.license` is a list, `ci.nix` falls back to its default value of `true` (it's not an attrset, so it can't have a `.free` attribute). If that list contains an unfree license, the actions can end up trying to build the package, and getting an error because `allowUnfree` isn't set.