### PR TITLE
flake.nix: simplify forAllSystems function.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -3,15 +3,7 @@
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
   outputs = { self, nixpkgs }:
     let
-      systems = [
-        "x86_64-linux"
-        "i686-linux"
-        "x86_64-darwin"
-        "aarch64-linux"
-        "armv6l-linux"
-        "armv7l-linux"
-      ];
-      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
+      forAllSystems = nixpkgs.lib.genAttrs nixpkgs.lib.systems.flakeExposed;
     in
     {
       legacyPackages = forAllSystems (system: import ./default.nix {


### PR DESCRIPTION
Also has the side effect of supporting more systems. + reducing the amount of manual maintenance and code in the repo