### PR TITLE
Update build workflow to use latest stable (25.11 -> 26.05)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
         nixPath:
           - nixpkgs=https://github.com/NixOS/nixpkgs/archive/refs/heads/nixpkgs-unstable.tar.gz
           - nixpkgs=https://github.com/NixOS/nixpkgs/archive/refs/heads/nixos-unstable.tar.gz
-          - nixpkgs=https://github.com/NixOS/nixpkgs/archive/refs/heads/nixos-25.11.tar.gz
+          - nixpkgs=https://github.com/NixOS/nixpkgs/archive/refs/heads/nixos-26.05.tar.gz
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository


### PR DESCRIPTION
First, is it a good idea always bump nixos tarball version by hand? Then is it correct to set nixpkgs variable among nixpkgs and nixos tarball URL? Apologize for my offensive.